### PR TITLE
Support more UNIX systems than Linux and Darwin

### DIFF
--- a/internal/relay/unix.go
+++ b/internal/relay/unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build !windows
 
 package relay
 


### PR DESCRIPTION
wpex would previously not compile on other systems than Windows, Linux and Darwin. It now compiles, e.g. for OpenBSD as well.

PS: Besides running `go test ./...` I have not ensured, that the tool works on OpenBSD. However, since it compiles, I don't see why it wouldn't.