### PR TITLE
Remove unnecessary code

### DIFF
--- a/internal/analyzer/checker.go
+++ b/internal/analyzer/checker.go
@@ -14,7 +14,7 @@ type macChecker struct {
 }
 
 func (c *macChecker) cookie(addr net.UDPAddr) [16]byte {
-	ticks := uint64(time.Now().Sub(c.start) / (time.Duration(120) * time.Minute))
+	ticks := uint64(time.Since(c.start) / (120 * time.Minute))
 	addrBytes, _ := addr.AddrPort().MarshalBinary()
 	return mac32(nil, c.secret, binary.BigEndian.AppendUint64(nil, ticks), addrBytes)
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -2,7 +2,6 @@ package relay
 
 import (
 	"context"
-	"fmt"
 	"github.com/weiiwang01/wpex/internal/analyzer"
 	"golang.org/x/time/rate"
 	"log"
@@ -36,11 +35,9 @@ func (r *Relay) relay(conn *net.UDPConn) {
 		packet := buf[:n]
 		peers, send := r.analyzer.Analyse(packet, *remoteAddr)
 		for _, peer := range peers {
-			if len(peers) > 1 {
-				if !r.limit.Allow() {
-					slog.Warn("broadcast rate limit exceeded", "src", remoteAddr.String(), "dst", peer.String())
-					continue
-				}
+			if !r.limit.Allow() {
+				slog.Warn("broadcast rate limit exceeded", "src", remoteAddr.String(), "dst", peer.String())
+				continue
 			}
 			_, err := conn.WriteToUDP(send, &peer)
 			if err != nil {
@@ -70,7 +67,7 @@ func Start(address string, publicKeys [][]byte, broadcastLimit *rate.Limiter) {
 	for i := 0; i < runtime.NumCPU(); i++ {
 		l, err := lc.ListenPacket(context.Background(), "udp", address)
 		if err != nil {
-			log.Fatal(fmt.Sprintf("failed to listen on %s: %s", address, err))
+			log.Fatalf("failed to listen on %s: %s", address, err)
 		}
 		conn := l.(*net.UDPConn)
 		go relay.relay(conn)

--- a/wpex.go
+++ b/wpex.go
@@ -49,7 +49,7 @@ func main() {
 	for _, allow := range allows {
 		k, err := base64.StdEncoding.DecodeString(allow)
 		if err != nil || len(k) != 32 {
-			log.Fatal(fmt.Sprintf("invalid wireguard public key: '%s'", allow))
+			log.Fatalf("invalid wireguard public key: '%s'", allow)
 		}
 		logger.Debug("allow wireguard public key", "key", allow)
 		allowKeys = append(allowKeys, k)


### PR DESCRIPTION
This pull request simplifies the code slightly by removing unnecessary code. I also found the previous `if len(peers) > 1` slightly confusing; was a different check intended here, or is it really obsolete (since we can only enter the loop, if the condition is already met)?